### PR TITLE
Add is_same<> to the scope_exit forwarding ctor.

### DIFF
--- a/include/pstore/support/portab.hpp
+++ b/include/pstore/support/portab.hpp
@@ -17,6 +17,8 @@
 #ifndef PSTORE_SUPPORT_PORTAB_HPP
 #define PSTORE_SUPPORT_PORTAB_HPP
 
+#include <type_traits>
+
 #ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  include <Windows.h>
@@ -201,5 +203,12 @@ namespace pstore {
 #ifdef _WIN32
 using ssize_t = SSIZE_T;
 #endif
+
+namespace pstore {
+
+  template <typename T>
+  using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+
+} // end namespace pstore
 
 #endif // PSTORE_SUPPORT_PORTAB_HPP

--- a/include/pstore/support/scope_guard.hpp
+++ b/include/pstore/support/scope_guard.hpp
@@ -28,8 +28,10 @@ namespace pstore {
   template <typename ExitFunction, typename = std::enable_if_t<std::is_invocable_v<ExitFunction>>>
   class scope_exit {
   public:
-    template <typename OtherExitFunction,
-              typename = std::enable_if_t<std::is_invocable_v<OtherExitFunction>>>
+    template <
+      typename OtherExitFunction,
+      typename = std::enable_if_t<std::is_invocable_v<OtherExitFunction> &&
+                                  !std::is_same_v<scope_exit, remove_cvref_t<OtherExitFunction>>>>
     explicit scope_exit (OtherExitFunction && other)
             : exit_function_{std::forward<OtherExitFunction> (other)} {}
 


### PR DESCRIPTION
This should satisfy SonarCloud that the single argument forwarding ctor is safe.

Move remove_cvref_t from maybe to portab to share the definition. Use it in the maybe definition.