### PR TITLE
Modernize: swap xx<>::type to xx_t<>.

### DIFF
--- a/include/pstore/adt/error_or.hpp
+++ b/include/pstore/adt/error_or.hpp
@@ -185,8 +185,7 @@ namespace pstore {
       return &val->get ();
     }
 
-    template <typename ErrorOr,
-              typename ResultType = typename inherit_const<ErrorOr, storage_type>::type>
+    template <typename ErrorOr, typename ResultType = inherit_const_t<ErrorOr, storage_type>>
     static ResultType * PSTORE_NONNULL value_storage_impl (ErrorOr && e) noexcept {
       PSTORE_ASSERT (!e.has_error_);
       return reinterpret_cast<ResultType *> (&e.storage_);
@@ -197,8 +196,7 @@ namespace pstore {
       return value_storage_impl (*this);
     }
 
-    template <typename ErrorOr,
-              typename ResultType = typename inherit_const<ErrorOr, std::error_code>::type>
+    template <typename ErrorOr, typename ResultType = inherit_const_t<ErrorOr, std::error_code>>
     static ResultType * PSTORE_NONNULL error_storage_impl (ErrorOr && e) noexcept {
       PSTORE_ASSERT (e.has_error_);
       return reinterpret_cast<ResultType *> (&e.error_storage_);
@@ -207,9 +205,8 @@ namespace pstore {
     std::error_code const * PSTORE_NONNULL get_error_storage () const noexcept;
 
     union {
-      typename std::aligned_storage_t<sizeof (storage_type), alignof (storage_type)> storage_;
-      std::aligned_storage<sizeof (std::error_code), alignof (std::error_code)>::type
-        error_storage_;
+      std::aligned_storage_t<sizeof (storage_type), alignof (storage_type)> storage_;
+      std::aligned_storage_t<sizeof (std::error_code), alignof (std::error_code)> error_storage_;
     };
     bool has_error_ = true;
   };

--- a/include/pstore/broker/spawn.hpp
+++ b/include/pstore/broker/spawn.hpp
@@ -85,7 +85,7 @@ namespace pstore::broker {
     private:
       static void close_handle (HANDLE h) noexcept;
 
-      std::unique_ptr<std::remove_pointer<HANDLE>::type, decltype (&close_handle)> const process_;
+      std::unique_ptr<std::remove_pointer_t<HANDLE>, decltype (&close_handle)> const process_;
       DWORD const group_;
     };
 

--- a/include/pstore/core/hamt_map.hpp
+++ b/include/pstore/core/hamt_map.hpp
@@ -303,14 +303,12 @@ namespace pstore {
                         gsl::not_null<parent_stack *> parents, bool is_upsert)
         -> std::pair<index_pointer, bool>;
 
-      template <
-        typename Database, typename HamtMap,
-        typename Iterator = typename inherit_const<Database, iterator, const_iterator>::type>
+      template <typename Database, typename HamtMap,
+                typename Iterator = inherit_const_t<Database, iterator, const_iterator>>
       static Iterator make_begin_iterator (Database & db, HamtMap & m);
 
-      template <
-        typename Database, typename HamtMap,
-        typename Iterator = typename inherit_const<Database, iterator, const_iterator>::type>
+      template <typename Database, typename HamtMap,
+                typename Iterator = inherit_const_t<Database, iterator, const_iterator>>
       static Iterator make_end_iterator (Database & db, HamtMap & m);
 
       /// Insert or insert_or_assign a node into a hamt_map.

--- a/include/pstore/core/index_types.hpp
+++ b/include/pstore/core/index_types.hpp
@@ -119,9 +119,8 @@ namespace pstore {
 
     /// Returns a pointer to a index, loading it from the store on first access. If 'create' is
     /// false and the index does not already exist then nullptr is returned.
-    template <
-      pstore::trailer::indices Index, typename Database = pstore::database,
-      typename Return = typename inherit_const<Database, typename enum_to_index<Index>::type>::type>
+    template <pstore::trailer::indices Index, typename Database = pstore::database,
+              typename Return = inherit_const_t<Database, typename enum_to_index<Index>::type>>
     std::shared_ptr<Return> get_index (Database & db, bool const create = true) {
       auto & dx = db.get_mutable_index (Index);
 

--- a/include/pstore/core/storage.hpp
+++ b/include/pstore/core/storage.hpp
@@ -206,8 +206,8 @@ namespace pstore {
                                 sat_iterator segment_it, sat_iterator segment_end);
 
     template <typename Storage,
-              typename ResultType = typename inherit_const<Storage, std::shared_ptr<void> const &,
-                                                           std::shared_ptr<void const>>::type>
+              typename ResultType = inherit_const_t<Storage, std::shared_ptr<void> const &,
+                                                    std::shared_ptr<void const>>>
     static auto segment_base_impl (Storage & storage, address::segment_type const segment) noexcept
       -> ResultType;
 
@@ -221,9 +221,8 @@ namespace pstore {
     /// \param storage  The instance of the storage class.
     /// \param addr  The store address.
     /// \returns  The pointer which corresponds to \p addr.
-    template <typename Storage,
-              typename ResultType = typename inherit_const<Storage, std::shared_ptr<void>,
-                                                           std::shared_ptr<void const>>::type>
+    template <typename Storage, typename ResultType = inherit_const_t<
+                                  Storage, std::shared_ptr<void>, std::shared_ptr<void const>>>
     static ResultType address_to_pointer_impl (Storage & storage, address const addr) noexcept;
 
     /// Converts a store address to the corresponding raw pointer.
@@ -236,8 +235,8 @@ namespace pstore {
     /// \param storage  The instance of the storage class.
     /// \param addr  The store address.
     /// \returns  The raw pointer which corresponds to \p addr.
-    template <typename Storage, typename ResultType = typename inherit_const<
-                                  Storage, std::uint8_t *, std::uint8_t const *>::type>
+    template <typename Storage,
+              typename ResultType = inherit_const_t<Storage, std::uint8_t *, std::uint8_t const *>>
     static ResultType address_to_raw_pointer_impl (Storage & storage, address addr) noexcept;
 
 
@@ -270,7 +269,7 @@ namespace pstore {
   inline auto storage::address_to_pointer_impl (Storage & storage, address const addr) noexcept
     -> ResultType {
     auto segment_base = storage.segment_base (addr.segment ());
-    using uint8_type = typename inherit_const<Storage, std::uint8_t>::type;
+    using uint8_type = inherit_const_t<Storage, std::uint8_t>;
     return {segment_base,
             std::static_pointer_cast<uint8_type> (segment_base).get () + addr.offset ()};
   }

--- a/include/pstore/exchange/export_section.hpp
+++ b/include/pstore/exchange/export_section.hpp
@@ -178,8 +178,7 @@ namespace pstore::exchange::export_ns {
       }
     };
 
-    template <repo::section_kind Kind,
-              typename Content = typename repo::enum_to_section<Kind>::type>
+    template <repo::section_kind Kind, typename Content = repo::enum_to_section_t<Kind>>
     struct section_exporter {
       template <typename OStream>
       OStream & operator() (OStream & os, indent const ind, class database const & db,
@@ -192,7 +191,7 @@ namespace pstore::exchange::export_ns {
   } // end namespace details
 
   template <repo::section_kind Kind, typename OStream,
-            typename Content = typename repo::enum_to_section<Kind>::type>
+            typename Content = repo::enum_to_section_t<Kind>>
   OStream & emit_section (OStream & os, indent const ind, class database const & db,
                           string_mapping const & strings, Content const & content,
                           bool const comments) {

--- a/include/pstore/http/block_for_input.hpp
+++ b/include/pstore/http/block_for_input.hpp
@@ -57,7 +57,7 @@ namespace pstore {
       constexpr auto timeout_seconds = 60L;
 
 #ifdef _WIN32
-      std::unique_ptr<std::remove_pointer<WSAEVENT>::type, decltype (&::WSACloseEvent)> event{
+      std::unique_ptr<std::remove_pointer_t<WSAEVENT>, decltype (&::WSACloseEvent)> event{
         ::WSACreateEvent (), &::WSACloseEvent};
       if (::WSAEventSelect (socket_fd.native_handle (), event.get (), FD_READ | FD_CLOSE) != 0) {
         // WSAGetLastError ()

--- a/include/pstore/http/serve_dynamic_content.hpp
+++ b/include/pstore/http/serve_dynamic_content.hpp
@@ -90,7 +90,7 @@ namespace pstore {
 
       template <typename T>
       auto clamp_to_signed_max (T v) noexcept -> std::make_signed_t<T> {
-        using st = typename std::make_signed<T>::type;
+        using st = std::make_signed_t<T>;
         constexpr auto maxs = std::numeric_limits<st>::max ();
         PSTORE_STATIC_ASSERT (maxs >= 0);
         return static_cast<st> (std::min (static_cast<T> (maxs), v));

--- a/include/pstore/mcrepo/fragment.hpp
+++ b/include/pstore/mcrepo/fragment.hpp
@@ -164,26 +164,26 @@ namespace pstore {
       /// Returns a const reference to the section data given the section kind. The section
       /// must exist in the fragment.
       template <section_kind Key>
-      auto at () const noexcept -> typename enum_to_section<Key>::type const & {
+      auto at () const noexcept -> enum_to_section_t<Key> const & {
         return at_impl<Key> (*this);
       }
       /// Returns a reference to the section data given the section kind. The section must
       /// exist in the fragment.
       template <section_kind Key>
-      auto at () noexcept -> typename enum_to_section<Key>::type & {
+      auto at () noexcept -> enum_to_section_t<Key> & {
         return at_impl<Key> (*this);
       }
 
       /// Returns a pointer to the section data given the section kind or nullptr if the
       /// section is not present.
       template <section_kind Key>
-      auto atp () const noexcept -> typename enum_to_section<Key>::type const * {
+      auto atp () const noexcept -> enum_to_section_t<Key> const * {
         return atp_impl<Key> (*this);
       }
       /// Returns a pointer to the section data given the section kind or nullptr if the
       /// section is not present.
       template <section_kind Key>
-      auto atp () noexcept -> typename enum_to_section<Key>::type * {
+      auto atp () noexcept -> enum_to_section_t<Key> * {
         return atp_impl<Key> (*this);
       }
       ///@}
@@ -275,8 +275,7 @@ namespace pstore {
       /// \returns A constant reference to the instance contained in the Key section if the
       ///   input fragment type is const; non-const otherwise.
       template <section_kind Key, typename Fragment,
-                typename ResultType =
-                  typename inherit_const<Fragment, typename enum_to_section<Key>::type>::type>
+                typename ResultType = inherit_const_t<Fragment, enum_to_section_t<Key>>>
       static ResultType & at_impl (Fragment && f) noexcept {
         PSTORE_ASSERT (f.has_section (Key));
         return f.template offset_to_instance<ResultType> (f.arr_[Key]);
@@ -292,8 +291,7 @@ namespace pstore {
       /// \returns A constant pointer to the instance contained in the Key section if the
       ///   input fragment type is const; non-const otherwise.
       template <section_kind Key, typename Fragment,
-                typename ResultType =
-                  typename inherit_const<Fragment, typename enum_to_section<Key>::type>::type>
+                typename ResultType = inherit_const_t<Fragment, enum_to_section_t<Key>>>
       static ResultType * atp_impl (Fragment && f) noexcept {
         return f.has_section (Key) ? &f.template at<Key> () : nullptr;
       }
@@ -433,7 +431,7 @@ case section_kind::k: name = #k; break;
       PSTORE_ASSERT (std::is_sorted (first, last, [] (value_type const & a, value_type const & b) {
         section_kind const akind = a.kind ();
         section_kind const bkind = b.kind ();
-        using utype = std::underlying_type<section_kind>::type;
+        using utype = std::underlying_type_t<section_kind>;
         return static_cast<utype> (akind) < static_cast<utype> (bkind);
       }));
 #endif

--- a/include/pstore/mcrepo/linked_definitions_section.hpp
+++ b/include/pstore/mcrepo/linked_definitions_section.hpp
@@ -148,7 +148,7 @@ namespace pstore {
 
     private:
       template <typename LinkedDefinitions,
-                typename ResultType = typename inherit_const<LinkedDefinitions, value_type>::type>
+                typename ResultType = inherit_const_t<LinkedDefinitions, value_type>>
       static ResultType & index_impl (LinkedDefinitions & v, std::size_t pos) {
         PSTORE_ASSERT (pos < v.size ());
         return v.definitions_[pos];
@@ -159,7 +159,7 @@ namespace pstore {
       value_type definitions_[1];
     };
 
-    PSTORE_STATIC_ASSERT (std::is_standard_layout<linked_definitions::value_type>::value);
+    PSTORE_STATIC_ASSERT (std::is_standard_layout_v<linked_definitions::value_type>);
     PSTORE_STATIC_ASSERT (sizeof (linked_definitions::value_type) == 32);
     PSTORE_STATIC_ASSERT (alignof (linked_definitions::value_type) == 16);
     PSTORE_STATIC_ASSERT (offsetof (linked_definitions::value_type, compilation) == 0);
@@ -173,7 +173,7 @@ namespace pstore {
       std::copy (begin, end, &definitions_[0]);
 
       unused_ = 0; // to suppress a warning about the field being unused.
-      PSTORE_STATIC_ASSERT (std::is_standard_layout<linked_definitions>::value);
+      PSTORE_STATIC_ASSERT (std::is_standard_layout_v<linked_definitions>);
       PSTORE_STATIC_ASSERT (alignof (linked_definitions) == 16);
       PSTORE_STATIC_ASSERT (offsetof (linked_definitions, size_) == 0);
       PSTORE_STATIC_ASSERT (offsetof (linked_definitions, unused_) == 8);

--- a/include/pstore/mcrepo/section.hpp
+++ b/include/pstore/mcrepo/section.hpp
@@ -53,14 +53,14 @@ namespace pstore {
     };
 #undef X
     constexpr auto num_section_kinds =
-      static_cast<std::underlying_type<section_kind>::type> (section_kind::last);
+      static_cast<std::underlying_type_t<section_kind>> (section_kind::last);
 
     std::ostream & operator<< (std::ostream & os, section_kind kind);
 
     constexpr auto first_repo_metadata_section = section_kind::linked_definitions;
 
     constexpr bool is_target_section (section_kind const t) noexcept {
-      using utype = std::underlying_type<section_kind>::type;
+      using utype = std::underlying_type_t<section_kind>;
       return static_cast<utype> (t) < static_cast<utype> (first_repo_metadata_section);
     }
 

--- a/include/pstore/serialize/types.hpp
+++ b/include/pstore/serialize/types.hpp
@@ -102,7 +102,7 @@
 namespace pstore::serialize {
 
   template <typename Archive>
-  using archive_result_type = typename std::remove_reference<Archive>::type::result_type;
+  using archive_result_type = typename std::remove_reference_t<Archive>::result_type;
 
   /// \brief The primary template for serialization of non standard layout types.
   ///
@@ -178,7 +178,7 @@ namespace pstore::serialize {
       /// This overload is called if Archive has a getn() method.
       template <typename Archive, typename Span>
       static void invoke (Archive && archive, Span span,
-                          decltype (&std::remove_reference<Archive>::type::template getn<Span>)) {
+                          decltype (&std::remove_reference_t<Archive>::template getn<Span>)) {
         archive.getn (span);
       }
     };
@@ -206,7 +206,7 @@ namespace pstore::serialize {
       template <typename Archive, typename SpanType>
       static void invoke (Archive && archive, SpanType span,
                           decltype (&serializer<typename SpanType::element_type>::template readn<
-                                    typename std::remove_reference<Archive>::type, SpanType>)) {
+                                    std::remove_reference_t<Archive>, SpanType>)) {
         serializer<typename SpanType::element_type>::readn (std::forward<Archive> (archive), span);
       }
     };
@@ -249,7 +249,7 @@ namespace pstore::serialize {
       template <typename Archive, typename SpanType>
       static auto invoke (Archive && archive, SpanType span,
                           decltype (&serializer<typename SpanType::element_type>::template writen<
-                                    typename std::remove_reference<Archive>::type, SpanType>))
+                                    std::remove_reference_t<Archive>, SpanType>))
         -> archive_result_type<Archive> {
         return serializer<typename SpanType::element_type>::writen (std::forward<Archive> (archive),
                                                                     span);

--- a/include/pstore/support/inherit_const.hpp
+++ b/include/pstore/support/inherit_const.hpp
@@ -114,10 +114,10 @@ namespace pstore {
   using inherit_const_t = typename inherit_const<T, R, RC>::type;
 
   static_assert (std::is_same_v<inherit_const_t<int, bool>, bool>, "int -> bool");
-  static_assert (std::is_same_v<inherit_const<int const, bool>::type, bool const>,
+  static_assert (std::is_same_v<inherit_const_t<int const, bool>, bool const>,
                  "int const -> bool const");
   static_assert (std::is_same_v<inherit_const_t<int &, bool>, bool>, "int& -> bool");
-  static_assert (std::is_same_v<inherit_const<int const &, bool>::type, bool const>,
+  static_assert (std::is_same_v<inherit_const_t<int const &, bool>, bool const>,
                  "int const & -> bool const");
   static_assert (std::is_same_v<inherit_const_t<int &&, bool>, bool>, "int && -> bool");
   static_assert (std::is_same_v<inherit_const_t<int const &&, bool>, bool const>,

--- a/include/pstore/support/utf.hpp
+++ b/include/pstore/support/utf.hpp
@@ -208,8 +208,7 @@ namespace pstore {
     auto utf16_to_code_point (InputIterator first, InputIterator last, SwapperFunction swapper)
       -> std::pair<InputIterator, char32_t> {
 
-      using value_type =
-        typename std::remove_cv<typename std::iterator_traits<InputIterator>::value_type>::type;
+      using value_type = std::remove_cv_t<typename std::iterator_traits<InputIterator>::value_type>;
       static_assert (std::is_same_v<value_type, char16_t>, "iterator must produce char16_t");
 
       PSTORE_ASSERT (first != last);

--- a/lib/broker/read_loop_win32.cpp
+++ b/lib/broker/read_loop_win32.cpp
@@ -150,7 +150,7 @@ namespace {
           : pipe_handle_{std::move (ph)}
           , command_processor_{cp}
           , record_file_{record_file} {
-    using T = std::remove_pointer<decltype (this)>::type;
+    using T = std::remove_pointer_t<decltype (this)>;
     static_assert (offsetof (T, overlap_) == 0,
                    "OVERLAPPED must be the first member of the request structure");
     PSTORE_ASSERT (pipe_handle_.valid ());

--- a/lib/exchange/import_error.cpp
+++ b/lib/exchange/import_error.cpp
@@ -111,7 +111,7 @@ namespace pstore::exchange::import_ns {
   }
 
   std::error_code make_error_code (error const e) noexcept {
-    static_assert (std::is_same_v<std::underlying_type<error>::type, int>,
+    static_assert (std::is_same_v<std::underlying_type_t<error>, int>,
                    "The underlying type of import error must be int");
     return {static_cast<int> (e), get_error_category ()};
   }

--- a/lib/mcrepo/compilation.cpp
+++ b/lib/mcrepo/compilation.cpp
@@ -46,8 +46,8 @@ namespace {
   constexpr void assert_enum_field_width (std::initializer_list<Enum> init) noexcept {
     (void) init;
     PSTORE_ASSERT (pstore::round_to_power_of_2 (
-                     static_cast<typename std::underlying_type<Enum>::type> (std::max (init)) +
-                     1U) == Bitfield::max () + 1U);
+                     static_cast<std::underlying_type_t<Enum>> (std::max (init)) + 1U) ==
+                   Bitfield::max () + 1U);
   }
 
 } // end anonymous namespace
@@ -84,8 +84,8 @@ definition::definition (pstore::index::digest const d, pstore::extent<fragment> 
 #define X(a) repo::visibility::a,
   assert_enum_field_width<enum visibility, decltype (visibility_)> ({PSTORE_REPO_VISIBILITIES});
 #undef X
-  linkage_ = static_cast<std::underlying_type<enum linkage>::type> (l);
-  visibility_ = static_cast<std::underlying_type<enum visibility>::type> (v);
+  linkage_ = static_cast<std::underlying_type_t<enum linkage>> (l);
+  visibility_ = static_cast<std::underlying_type_t<enum visibility>> (v);
 }
 
 

--- a/lib/mcrepo/fragment.cpp
+++ b/lib/mcrepo/fragment.cpp
@@ -34,7 +34,7 @@ namespace {
 
   /// A type which is suitable for holding an instance of any of the dispatcher subclasses.
   using dispatcher_buffer =
-    std::aligned_storage<dispatcher_characteristics::size, dispatcher_characteristics::align>::type;
+    std::aligned_storage_t<dispatcher_characteristics::size, dispatcher_characteristics::align>;
 
   struct nop_deleter {
     void operator() (dispatcher * const) const noexcept {}
@@ -47,8 +47,7 @@ namespace {
   dispatcher_ptr
   make_dispatcher_for_kind (fragment const & f,
                             pstore::gsl::not_null<dispatcher_buffer *> const buffer) {
-    using dispatcher_type =
-      typename section_to_dispatcher<typename enum_to_section<Kind>::type>::type;
+    using dispatcher_type = typename section_to_dispatcher<enum_to_section_t<Kind>>::type;
     static_assert (sizeof (dispatcher_type) <= sizeof (dispatcher_buffer),
                    "dispatcher buffer is too small");
     static_assert (alignof (dispatcher_type) <= alignof (dispatcher_buffer),

--- a/lib/mcrepo/repo_error.cpp
+++ b/lib/mcrepo/repo_error.cpp
@@ -37,7 +37,7 @@ namespace pstore {
     }
 
     std::error_code make_error_code (pstore::repo::error_code const e) {
-      static_assert (std::is_same_v<std::underlying_type<decltype (e)>::type, int>,
+      static_assert (std::is_same_v<std::underlying_type_t<decltype (e)>, int>,
                      "base type of error_code must be int to permit safe static cast");
       static pstore::repo::error_category const cat;
       return {static_cast<int> (e), cat};

--- a/lib/os/file_posix.cpp
+++ b/lib/os/file_posix.cpp
@@ -252,7 +252,7 @@ namespace pstore::file {
   void file_handle::seek (std::uint64_t position) {
     this->ensure_open ();
 
-    using common_type = std::common_type<uoff_type, std::uint64_t>::type;
+    using common_type = std::common_type_t<uoff_type, std::uint64_t>;
     static constexpr auto max = static_cast<common_type> (std::numeric_limits<off_t>::max ());
 
     int mode = SEEK_SET;

--- a/lib/support/utf_win32.cpp
+++ b/lib/support/utf_win32.cpp
@@ -257,7 +257,7 @@ namespace pstore {
         }
 
         // Find out the number of wchars that the conversion will produce.
-        using common = std::common_type<int, std::size_t>::type;
+        using common = std::common_type_t<int, std::size_t>;
         auto const input_length = std::min (static_cast<common> (length),
                                             static_cast<common> (std::numeric_limits<int>::max ()));
         int size_needed = ::MultiByteToWideChar (CP_ACP, MB_ERR_INVALID_CHARS, mbcs,

--- a/tools/index_structure/switches.cpp
+++ b/tools/index_structure/switches.cpp
@@ -66,7 +66,7 @@ std::pair<switches, int> get_switches (int argc, tchar * argv[]) {
   sw.revision = static_cast<unsigned> (revision.get ());
   sw.db_path = db_path.get ();
   for (pstore::trailer::indices idx : index_names_opt) {
-    sw.selected.set (static_cast<std::underlying_type<pstore::trailer::indices>::type> (idx));
+    sw.selected.set (static_cast<std::underlying_type_t<pstore::trailer::indices>> (idx));
   }
   return {sw, EXIT_SUCCESS};
 }

--- a/tools/index_structure/switches.hpp
+++ b/tools/index_structure/switches.hpp
@@ -24,14 +24,14 @@
 #include "pstore/config/config.hpp"
 
 struct switches {
-  std::bitset<static_cast<std::underlying_type<pstore::trailer::indices>::type> (
+  std::bitset<static_cast<std::underlying_type_t<pstore::trailer::indices>> (
     pstore::trailer::indices::last)>
     selected;
   unsigned revision = pstore::head_revision;
   std::string db_path;
 
   bool test (pstore::trailer::indices idx) const {
-    auto const position = static_cast<std::underlying_type<pstore::trailer::indices>::type> (idx);
+    auto const position = static_cast<std::underlying_type_t<pstore::trailer::indices>> (idx);
     PSTORE_ASSERT (idx < pstore::trailer::indices::last);
     return selected.test (position);
   }


### PR DESCRIPTION
More C++17 modernization. I've converted std::XX<YY>::type to std::XX_t<YY> pretty much everywhere now.