### PR TITLE
Guard the options subclass variadic ctors.

### DIFF
--- a/include/pstore/command_line/command_line.hpp
+++ b/include/pstore/command_line/command_line.hpp
@@ -60,7 +60,7 @@ namespace pstore::command_line {
             , program_name_{std::move (program_name)}
             , overview_{std::move (program_overview)}
             , outs_{outs} {
-      apply_to_option (*this, std::forward<Mods> (mods)...);
+      apply_modifiers_to_option (*this, std::forward<Mods> (mods)...);
     }
 
     help (help const &) = delete;

--- a/include/pstore/command_line/option.hpp
+++ b/include/pstore/command_line/option.hpp
@@ -126,7 +126,6 @@ namespace pstore::command_line {
   }
 
   /// Checks whether Option is a type derived from pstore::command_line::option.
-  /// \tparam Option  The type to be tested.
   template <typename Option>
   inline constexpr bool is_option =
     std::is_base_of_v<option, std::remove_reference_t<std::remove_cv_t<Option>>>;

--- a/include/pstore/command_line/option.hpp
+++ b/include/pstore/command_line/option.hpp
@@ -125,6 +125,12 @@ namespace pstore::command_line {
     return result;
   }
 
+  /// Checks whether Option is a type derived from pstore::command_line::option.
+  /// \tparam Option  The type to be tested.
+  template <typename Option>
+  inline constexpr bool is_option =
+    std::is_base_of_v<option, std::remove_reference_t<std::remove_cv_t<Option>>>;
+
   //*           _    *
   //*  ___ _ __| |_  *
   //* / _ \ '_ \  _| *
@@ -137,7 +143,7 @@ namespace pstore::command_line {
   public:
     template <typename... Mods>
     explicit opt (Mods &&... mods) {
-      apply_to_option (*this, std::forward<Mods> (mods)...);
+      apply_modifiers_to_option (*this, std::forward<Mods> (mods)...);
     }
     opt (opt const &) = delete;
     opt (opt &&) noexcept = delete;
@@ -205,7 +211,7 @@ namespace pstore::command_line {
   public:
     template <typename... Mods>
     explicit opt (Mods &&... mods) {
-      apply_to_option (*this, std::forward<Mods> (mods)...);
+      apply_modifiers_to_option (*this, std::forward<Mods> (mods)...);
     }
     opt (opt const &) = delete;
     opt (opt &&) noexcept = delete;
@@ -251,7 +257,7 @@ namespace pstore::command_line {
     template <typename... Mods>
     explicit list (Mods &&... mods)
             : option (occurrences_flag::zero_or_more) {
-      apply_to_option (*this, std::forward<Mods> (mods)...);
+      apply_modifiers_to_option (*this, std::forward<Mods> (mods)...);
     }
 
     list (list const &) = delete;
@@ -325,7 +331,7 @@ namespace pstore::command_line {
   public:
     template <typename... Mods>
     explicit alias (Mods &&... mods) {
-      apply_to_option (*this, std::forward<Mods> (mods)...);
+      apply_modifiers_to_option (*this, std::forward<Mods> (mods)...);
     }
 
     alias (alias const &) = delete;


### PR DESCRIPTION
Prevent the `option` subclass ctors which take variadic arguments from copying or moving objects of the same type. Each of them calls `apply_modifiers_to_option()` which does the real work of the ctor, so the protection is applied there.