### PR TITLE
Tell CodeQL to ignore the lit 3d-party code.

### DIFF
--- a/.github/codeql-analysis.yml
+++ b/.github/codeql-analysis.yml
@@ -1,5 +1,0 @@
-name: "My CodeQL config"
-
-paths-ignore:
-  - 3rd_party/lit
-

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -60,6 +60,9 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        config: |
+          paths-ignore:
+            - 3rd_party/lit
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
A secnd attempt at this places the "paths-ignore" in the workflow file rather than a separate YAML file.